### PR TITLE
Update submodules after checking out ejdb

### DIFF
--- a/build-ios.sh
+++ b/build-ios.sh
@@ -20,6 +20,7 @@ if [[ -z "${EJDB_ROOT}" ]]; then
   echo "Source root: ${EJDB_ROOT}"
   echo "Checkout https://github.com/Softmotions/ejdb"
   git clone "https://github.com/Softmotions/ejdb" "${EJDB_ROOT}"
+  (cd "${EJDB_ROOT}" && git submodule update --init)
 else
   echo "Source root: ${EJDB_ROOT}"
 fi


### PR DESCRIPTION
run "git submodule update --init" after checking out https://github.com/Softmotions/ejdb to ensure submodules are available for the build

 resolves #341

Fixes Softmotions/ejdb#341